### PR TITLE
feat(keyboard): add basic PIC keyboard driver with interrupt handling

### DIFF
--- a/src/kernel/arch/i386/drivers/keyboard.c
+++ b/src/kernel/arch/i386/drivers/keyboard.c
@@ -1,0 +1,60 @@
+// kernel/arch/i386/drivers/keyboard.c
+#include <kernel/drivers/keyboard.h>
+#include <kernel/arch/portio.h>
+#include <kernel/arch/isr.h>
+#include <kernel/arch/pic.h>
+#include <kernel/printk.h>
+#include <stdint.h>
+
+/* Keyboard I/O ports */
+#define KBD_DATA_PORT   0x60
+#define KBD_STATUS_PORT 0x64
+
+// PIC IRQs vector
+#define KBD_IRQ 1
+
+/* Small scancode->ascii table for set 1 (non-shifted). Extend as needed. */
+static const char scancode_to_ascii[128] = {
+    0,  27, '1','2','3','4','5','6','7','8','9','0','-','=','\b',
+    '\t','q','w','e','r','t','y','u','i','o','p','[',']','\n', /* Enter */
+    0,  'a','s','d','f','g','h','j','k','l',';','\'','`',0,
+    '\\','z','x','c','v','b','n','m',',','.','/',0,'*',0,' ',
+    /* remaining mostly 0 */
+};
+
+
+/* ======================================================================
+ * Keyboard interrupt handler
+ * ====================================================================== */
+
+static void keyboard_irq_handler(regs_t *regs) {
+    (void)regs;
+    uint8_t sc = inb(KBD_DATA_PORT);
+    if (sc & 0x80) {
+        /* key release - ignore for now */
+    } else {
+        char c = 0;
+        if (sc < sizeof(scancode_to_ascii))
+            c = scancode_to_ascii[sc];
+        if (c) {
+            printk("%c", c);
+        }
+    }
+    /* Tell PIC we're done */
+    pic_send_eoi(KBD_IRQ); // IRQ1
+}
+
+
+/* ======================================================================
+ * Keyboard driver Initialization
+ * ====================================================================== */
+
+/* Startup helper to register keyboard driver. Call from kernel init after idt/pic setup */
+void keyboard_init(void) {
+    /* mask/unmask IRQ1 as needed. We'll clear the mask for IRQ1 */
+    pic_clear_mask_irq(KBD_IRQ);
+
+    /* register handler for IRQ1 (IRQ number not vector): register for irq index 1 */
+    register_irq_handler(KBD_IRQ, keyboard_irq_handler);
+}
+

--- a/src/kernel/include/kernel/drivers/keyboard.h
+++ b/src/kernel/include/kernel/drivers/keyboard.h
@@ -1,0 +1,6 @@
+#ifndef __KERNEL_DRIVERS_KEYBOARD_H__
+#define __KERNEL_DRIVERS_KEYBOARD_H__
+
+void keyboard_init(void);
+
+#endif

--- a/src/kernel/kernel/kernel.c
+++ b/src/kernel/kernel/kernel.c
@@ -6,6 +6,7 @@
 #include <kernel/arch/lapic.h>
 #include <kernel/arch/pic.h>
 #include <kernel/arch/portio.h>
+#include <kernel/drivers/keyboard.h>
 #include <kernel/arch/timer.h>
 #include <kernel/drivers/tty.h>
 #include <kernel/printk.h>
@@ -33,12 +34,14 @@ void kernel_main(uint32_t magic, multiboot_info_t *mb_info_ptr) {
         printk("[CPUID] Loaded\n");
     }
 
-    //pic_init();
+    pic_init();
     //pit_init();
+    keyboard_init();
 
-    lapic_init();
-
-    lapic_timer_init(1, 32);
+    // Currently unused
+    //lapic_init();
+    //lapic_timer_init(1, 32);
+    //lapic_keyboard_init();
 
     enable_interrupts();
 


### PR DESCRIPTION
Implemented a simple PIC keyboard driver that handles keyboard interrupts and processes key inputs. This lays the foundation for future input handling and system interaction.

This commit resolves issue #2.